### PR TITLE
add 499 to req to avoid ugly crashes in the logs

### DIFF
--- a/src/cowboyku_req.erl
+++ b/src/cowboyku_req.erl
@@ -1532,6 +1532,7 @@ status(426) -> <<"426 Upgrade Required">>;
 status(428) -> <<"428 Precondition Required">>;
 status(429) -> <<"429 Too Many Requests">>;
 status(431) -> <<"431 Request Header Fields Too Large">>;
+status(499) -> <<"499 Client Disconnected">>;
 status(500) -> <<"500 Internal Server Error">>;
 status(501) -> <<"501 Not Implemented">>;
 status(502) -> <<"502 Bad Gateway">>;


### PR DESCRIPTION
This shouldn't affect the end user, and I am not sure that it can ever be returned, but it seems to be crashing anyway, and sprinkling the below all over the logs:

```
  {function_clause,[
    {cowboyku_req,status,[499],[{file,"src/cowboyku_req.erl"},{line,1488}]},
    {cowboyku_req,response,6,[{file,"src/cowboyku_req.erl"},{line,1366}]},
    {cowboyku_req,reply_no_compress,8,[{file,"src/cowboyku_req.erl"},{line,1096}]},
    {cowboyku_req,reply,4,[{file,"src/cowboyku_req.erl"},{line,1051}]},
    {cowboyku_req,maybe_reply,2,[{file,"src/cowboyku_req.erl"},{line,1166}]},
    {cowboyku_protocol,error_terminate,3,[{file,"src/cowboyku_protocol.erl"},{line,596}]}]}
```

499 is the code that we return when the client has disconnected early.  It seems that the response is generated on error exit even though there is no one connected to return it to?
