### PR TITLE
400 Bad request when empty Expect header is provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ doc/edoc-info
 ebin
 logs
 relx
-test/*.beam
+*.beam
+_build

--- a/Makefile.erlang.mk
+++ b/Makefile.erlang.mk
@@ -1,0 +1,31 @@
+# See LICENSE for licensing information.
+
+PROJECT = cowboyku
+
+# Options.
+
+COMPILE_FIRST = cowboyku_middleware cowboyku_sub_protocol
+CT_SUITES = eunit http spdy ws
+PLT_APPS = crypto public_key ssl
+
+# Dependencies.
+
+DEPS = cowlib ranch
+dep_cowlib = pkg://cowlib 0.4.0
+dep_ranch = pkg://ranch 0.9.0
+
+TEST_DEPS = ct_helper gun
+dep_ct_helper = https://github.com/extend/ct_helper.git master
+dep_gun = pkg://gun master
+
+# Standard targets.
+
+include erlang.mk
+
+# Extra targets.
+
+.PHONY: autobahn
+
+autobahn: clean clean-deps deps app build-tests
+	@mkdir -p logs/
+	@$(CT_RUN) -suite autobahn_SUITE

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Cowboyku
-========
+# Cowboyku
 
 Cowboy is a small, fast and modular HTTP server written in Erlang.
 Cowboyku is a fork of that server used in conjunction with
@@ -21,11 +20,35 @@ Depending on developments in the Cowboy servers and Heroku's Routing team
 agenda, we might eventually just drop this fork and go back to mainline (or
 update it) without further notice.
 
-Sponsors of the Original project
---------------------------------
+## A Herokai's Guide to Cowboyku Development
+
+Cowboyku has been updated to run with `rebar3` because that's what the
+rest of the stack at Heroku uses, and for the rare occasions that an
+update is needed for Cowboyku, it's more trouble than it's worth to
+use a completely different build system.
+
+`make test` is kind of racy, and the tests have been polished to try
+and eliminate some of them, but it's not perfect.
+
+### Autobahn
+
+The Autobahn suite does something with python to test websockets. It's
+disabled by default so you don't waste your life trying to get it
+working locally. You can run it with `AUTOBAHN=1 make test` but you'll
+probably have to get your local environment in good shape first.
+
+YMMV, but you can try this:
+
+```
+pip install -U virtualenv twisted autobahn autobahntestsuite
+```
+
+but if that doesn't work, you're on your own.
+
+
+# Sponsors of the Original project
 
 The SPDY protocol development is sponsored
 by [LeoFS Cloud Storage](http://www.leofs.org).
 
 The project is currently sponsored by [Kato.im](https://kato.im/).
-

--- a/rebar.config
+++ b/rebar.config
@@ -2,3 +2,12 @@
 	{cowlib, ".*", {git, "git://github.com/extend/cowlib.git", "0.4.0"}},
 	{ranch, ".*", {git, "git://github.com/extend/ranch.git", "0.9.0"}}
 ]}.
+
+{profiles, [
+  {test, [
+    {deps, [
+      {ct_helper, ".*", {git, "https://github.com/extend/ct_helper.git", {branch, "master"}}},
+            {gun, ".*", {git, "https://github.com/extend/gun.git", {ref, "ea2de24f18741fc89d7a1dd6a3a0a43f3ccb1fd4"}}}
+     ]}
+   ]}
+ ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+[{<<"cowlib">>,
+  {git,"git://github.com/extend/cowlib.git",
+       {ref,"63298e8e160031a70efff86a1acde7e7db1fcda6"}},
+  0},
+ {<<"ranch">>,
+  {git,"git://github.com/extend/ranch.git",
+       {ref,"5df1f222f94e08abdcab7084f5e13027143cc222"}},
+  0}].

--- a/src/cowboyku_req.erl
+++ b/src/cowboyku_req.erl
@@ -39,6 +39,9 @@
 %% track of the request and response state. Doing so allows Cowboyku to do
 %% some lazy evaluation and cache results when possible.
 -module(cowboyku_req).
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
 
 -define(POLL_INTERVAL, 1000).
 
@@ -438,7 +441,7 @@ parse_header(Name = <<"cookie">>, Req, Default) ->
 parse_header(Name = <<"expect">>, Req, Default) ->
 	parse_header(Name, Req, Default,
 		fun (Value) ->
-			cowboyku_http:nonempty_list(Value, fun cowboyku_http:expectation/2)
+			cowboyku_http:list(Value, fun cowboyku_http:expectation/2)
 		end);
 parse_header(Name, Req, Default)
 		when Name =:= <<"if-match">>;
@@ -1612,5 +1615,11 @@ merge_headers_test_() ->
 		  {<<"server">>,<<"Cowboy">>}]}
 	],
 	[fun() -> Res = merge_headers(L,R) end || {L, R, Res} <- Tests].
+
+parse_expect_headers_test() ->
+    Req = #http_req{headers=[{<<"expect">>,<<"">>}]},
+    {ok, "", NewReq} = parse_header(<<"expect">>, Req),
+
+    ok.
 
 -endif.

--- a/test/autobahn_SUITE.erl
+++ b/test/autobahn_SUITE.erl
@@ -29,7 +29,11 @@
 %% ct.
 
 all() ->
-	[{group, autobahn}].
+    case os:getenv("AUTOBAHN") of
+        false -> [];
+        _ ->
+            [{group, autobahn}]
+    end.
 
 groups() ->
 	BaseTests = [run_tests],
@@ -49,7 +53,7 @@ init_per_suite(Config) ->
 	os:putenv("AB_TESTS_PRIV", ?config(priv_dir, Config)),
 	BinPath = filename:join(?config(data_dir, Config), "test.py"),
 	Stdout = os:cmd(BinPath ++ " setup"),
-	ct:log("~s~n", [Stdout]),
+	ct:pal("Setup: ~s~n", [Stdout]),
 	case string:str(Stdout, "AB-TESTS-SETUP-OK") of
 		0 -> erlang:error(failed);
 		_ -> [{env_path, EnvPath},{bin_path,BinPath}|Config]

--- a/test/autobahn_SUITE_data/test.py
+++ b/test/autobahn_SUITE_data/test.py
@@ -8,7 +8,7 @@ import subprocess
 AB_TESTS_ENV = os.getenv("AB_TESTS_ENV")
 AB_TESTS_PRIV = os.getenv("AB_TESTS_PRIV")
 
-VIRTUALENV_URL = 'https://raw.github.com/pypa/virtualenv/master/virtualenv.py'
+VIRTUALENV_URL = 'https://raw.githubusercontent.com/pypa/virtualenv/master/virtualenv.py'
 VIRTUALENV_BIN = os.path.join(AB_TESTS_ENV, "virtualenv.py")
 INSTALL_BIN = os.path.join(AB_TESTS_ENV, "bin", "easy_install")
 
@@ -26,10 +26,10 @@ def install_env(env):
     Install a new virtualenv at a path and also install the Autobahn package.
     """
     os.makedirs(env) if not os.path.isdir(env) else None
-    subprocess.check_call(["curl", "-sS", VIRTUALENV_URL, "-o", VIRTUALENV_BIN])
-    subprocess.check_call(["python", VIRTUALENV_BIN, env])
+    ##subprocess.check_call(["curl", "-sS", VIRTUALENV_URL, "-o", VIRTUALENV_BIN])
+    subprocess.check_call(["virtualenv", env, "--system-site-packages"])
     activate_env(env)
-    subprocess.check_call([INSTALL_BIN, "http://pypi.python.org/packages/2.7/a/autobahntestsuite/autobahntestsuite-0.5.3-py2.7.egg"])
+    ##subprocess.check_call([INSTALL_BIN, "http://pypi.python.org/packages/2.7/a/autobahntestsuite/autobahntestsuite-0.5.3-py2.7.egg"])
 
 def client_config():
     """

--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -225,6 +225,7 @@ init_per_group(http, Config) ->
 		{max_keepalive, 50},
 		{timeout, 500}
 	]),
+  timer:sleep(1000),
 	Port = ranch:get_port(http),
 	{ok, Client} = cowboyku_client:init([]),
 	[{scheme, <<"http">>}, {port, Port}, {opts, []},
@@ -241,6 +242,7 @@ init_per_group(https, Config) ->
 		{max_keepalive, 50},
 		{timeout, 500}
 	]),
+  timer:sleep(500),
 	Port = ranch:get_port(https),
 	{ok, Client} = cowboyku_client:init(Opts),
 	[{scheme, <<"https">>}, {port, Port}, {opts, Opts},
@@ -253,6 +255,7 @@ init_per_group(http_compress, Config) ->
 		{max_keepalive, 50},
 		{timeout, 500}
 	]),
+  timer:sleep(500),
 	Port = ranch:get_port(http_compress),
 	{ok, Client} = cowboyku_client:init([]),
 	[{scheme, <<"http">>}, {port, Port}, {opts, []},
@@ -270,6 +273,7 @@ init_per_group(https_compress, Config) ->
 		{max_keepalive, 50},
 		{timeout, 500}
 	]),
+  timer:sleep(500),
 	Port = ranch:get_port(https_compress),
 	{ok, Client} = cowboyku_client:init(Opts),
 	[{scheme, <<"https">>}, {port, Port}, {opts, Opts},


### PR DESCRIPTION
In typhoeus/ethon#134, a regression was identified when using Heroku services due to an empty `Expect` header.

However, this seems to be RFC-compliant behaviour that `cURL` supports and Heroku seems to return `400 Bad Request` only when an `Expect` header is specified:

```
~ ❯❯❯ curl -v -H "Expect;" -X HEAD https://atom-slack.herokuapp.com/                                              ⏎
Warning: Setting custom HTTP method to HEAD with -X/--request may not work the
Warning: way you want. Consider using -I/--head instead.
*   Trying 107.22.227.63...
* TCP_NODELAY set
* Connected to atom-slack.herokuapp.com (107.22.227.63) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate: *.herokuapp.com
* Server certificate: DigiCert SHA2 High Assurance Server CA
* Server certificate: DigiCert High Assurance EV Root CA
> HEAD / HTTP/1.1
> Host: atom-slack.herokuapp.com
> User-Agent: curl/7.51.0
> Accept: */*
> Expect:
>
< HTTP/1.1 400 Bad Request
< Connection: keep-alive
< Server: Cowboy
< Date: Fri, 02 Dec 2016 19:17:17 GMT
< Content-Length: 0
<
* Curl_http_done: called premature == 0
* Connection #0 to host atom-slack.herokuapp.com left intact
```

When other empty header is specified, no issue arises:

```
~ ❯❯❯ curl -v -H "X-Custom;" -X HEAD https://atom-slack.herokuapp.com/
Warning: Setting custom HTTP method to HEAD with -X/--request may not work the
Warning: way you want. Consider using -I/--head instead.
*   Trying 107.22.227.63...
* TCP_NODELAY set
* Connected to atom-slack.herokuapp.com (107.22.227.63) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate: *.herokuapp.com
* Server certificate: DigiCert SHA2 High Assurance Server CA
* Server certificate: DigiCert High Assurance EV Root CA
> HEAD / HTTP/1.1
> Host: atom-slack.herokuapp.com
> User-Agent: curl/7.51.0
> Accept: */*
> X-Custom:
>
< HTTP/1.1 200 OK
< Server: Cowboy
< Connection: keep-alive
< X-Powered-By: Express
< Content-Type: text/html; charset=utf-8
< Content-Length: 3474
< Etag: W/"EYrzv+0AYWeW/B0I7iV9pw=="
< Date: Fri, 02 Dec 2016 19:17:04 GMT
< Via: 1.1 vegur
```

